### PR TITLE
Fix codecov CI and update template

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,7 +1,7 @@
 {
   "template": "https://github.com/scverse/cookiecutter-scverse",
-  "commit": "57f6267716826dad73baba46dc3c00fe7262c459",
-  "checkout": "v0.1.4",
+  "commit": "c21b82bf134f3a0f13db7482d4fb04ca1f562d59",
+  "checkout": "main",
   "context": {
     "cookiecutter": {
       "project_name": "biolord",

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,15 +6,21 @@ on:
     pull_request:
         branches: [main]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     package:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Set up Python 3.10
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: "3.10"
+                  cache: "pip"
+                  cache-dependency-path: "**/pyproject.toml"
             - name: Install build dependencies
               run: python -m pip install --upgrade pip wheel twine build
             - name: Build package

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -43,4 +43,4 @@ jobs:
                       manually merge these changes.**
 
                       For more information about the template sync, please refer to the
-                      [template documentation](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/developer_docs.html#automated-template-sync).
+                      [template documentation](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#automated-template-sync).

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,10 @@ on:
     pull_request:
         branches: [main]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     test:
         runs-on: ${{ matrix.os }}
@@ -24,27 +28,17 @@ jobs:
             PYTHON: ${{ matrix.python }}
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Set up Python ${{ matrix.python }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python }}
+                  cache: "pip"
+                  cache-dependency-path: "**/pyproject.toml"
 
-            - name: Get pip cache dir
-              id: pip-cache-dir
-              run: |
-                  echo "::set-output name=dir::$(pip cache dir)"
-            - name: Restore pip cache
-              uses: actions/cache@v2
-              with:
-                  path: ${{ steps.pip-cache-dir.outputs.dir }}
-                  key: pip-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml') }}
-                  restore-keys: |
-                      pip-${{ runner.os }}-${{ env.pythonLocation }}-
             - name: Install test dependencies
               run: |
                   python -m pip install --upgrade pip wheel
-                  pip install codecov
             - name: Install dependencies
               run: |
                   pip install ".[dev,test]"

--- a/.github/workflows/test.yaml.rej
+++ b/.github/workflows/test.yaml.rej
@@ -1,0 +1,10 @@
+diff a/.github/workflows/test.yaml b/.github/workflows/test.yaml	(rejected hunks)
+@@ -56,7 +50,4 @@ jobs:
+               run: |
+                   pytest -v --cov --color=yes
+             - name: Upload coverage
+-              env:
+-                  CODECOV_NAME: ${{ matrix.python }}-${{ matrix.os }}
+-              run: |
+-                  codecov --required --flags=unittests
++              uses: codecov/codecov-action@v3

--- a/docs/conf.py.rej
+++ b/docs/conf.py.rej
@@ -1,26 +1,18 @@
 diff a/docs/conf.py b/docs/conf.py	(rejected hunks)
-@@ -65,7 +65,7 @@ napoleon_numpy_docstring = True
- napoleon_include_init_with_doc = False
- napoleon_use_rtype = True  # having a separate entry generally helps readability
- napoleon_use_param = True
--myst_heading_anchors = 3  # create anchors for h1-h3
-+myst_heading_anchors = 6  # create anchors for h1-h6
- myst_enable_extensions = [
-     "amsmath",
-     "colon_fence",
-@@ -87,6 +87,7 @@ source_suffix = {
- }
+@@ -16,12 +16,15 @@ sys.path.insert(0, str(HERE / "extensions"))
  
- intersphinx_mapping = {
-+    "python": ("https://docs.python.org/3", None),
-     "anndata": ("https://anndata.readthedocs.io/en/stable/", None),
-     "numpy": ("https://numpy.org/doc/stable/", None),
- }
-@@ -109,6 +110,7 @@ html_title = project_name
- html_theme_options = {
-     "repository_url": repository_url,
-     "use_repository_button": True,
-+    "path_to_docs": "docs/",
- }
+ # -- Project information -----------------------------------------------------
  
- pygments_style = "default"
++# NOTE: If you installed your project in editable mode, this might be stale.
++#       If this is the case, reinstall it to refresh the metadata
+ info = metadata("biolord")
+ project_name = info["Name"]
+ author = info["Author"]
+ copyright = f"{datetime.now():%Y}, {author}."
+ version = info["Version"]
+-repository_url = f"https://github.com/zoepiran/{project_name}"
++urls = dict(pu.split(", ") for pu in info.get_all("Project-URL"))
++repository_url = urls["Source"]
+ 
+ # The full version, including alpha/beta/rc tags
+ release = info["Version"]

--- a/pyproject.toml.rej
+++ b/pyproject.toml.rej
@@ -1,94 +1,11 @@
 diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
-@@ -34,7 +33,7 @@ dev = [
- ]
- doc = [
-     "sphinx>=4",
--    "sphinx-book-theme>=0.3.3",
-+    "sphinx-book-theme>=1.0.0",
-     "myst-nb",
-     "sphinxcontrib-bibtex>=1.0.0",
-     "sphinx-autodoc-typehints",
-@@ -61,32 +60,59 @@ addopts = [
-     "--import-mode=importlib",  # allow using test files with same name
+@@ -109,6 +109,9 @@ ignore = [
+     "D213",
  ]
  
--[tool.isort]
--include_trailing_comma = true
--multi_line_output = 3
--profile = "black"
--skip_glob = ["docs/*"]
--
- [tool.black]
- line-length = 120
--target-version = ['py38']
--include = '\.pyi?$'
--exclude = '''
--(
--  /(
--      \.eggs
--    | \.git
--    | \.hg
--    | \.mypy_cache
--    | \.tox
--    | \.venv
--    | _build
--    | buck-out
--    | build
--    | dist
--  )/
--)
--'''
-+target-version = ["py38"]
++[tool.ruff.pydocstyle]
++convention = "numpy"
 +
-+[tool.ruff]
-+src = ["src"]
-+line-length = 120
-+target-version = "py38"
-+select = [
-+    "F",  # Errors detected by Pyflakes
-+    "E",  # Error detected by Pycodestyle
-+    "W",  # Warning detected by Pycodestyle
-+    "I",  # isort
-+    "D",  # pydocstyle
-+    "B",  # flake8-bugbear
-+    "TID",  # flake8-tidy-imports
-+    "C4",  # flake8-comprehensions
-+    "BLE",  # flake8-blind-except
-+    "UP",  # pyupgrade
-+    "RUF100",  # Report unused noqa directives
-+]
-+ignore = [
-+    # line too long -> we accept long comment lines; black gets rid of long code lines
-+    "E501",
-+    # Do not assign a lambda expression, use a def -> lambda expression assignments are convenient
-+    "E731",
-+    # allow I, O, l as variable names -> I is the identity matrix
-+    "E741",
-+    # Missing docstring in public package
-+    "D104",
-+    # Missing docstring in public module
-+    "D100",
-+    # Missing docstring in __init__
-+    "D107",
-+    # Errors from function calls in argument defaults. These are fine when the result is immutable.
-+    "B008",
-+    # __magic__ methods are are often self-explanatory, allow missing docstrings
-+    "D105",
-+    # first line should end with a period [Bug: doesn't work with single-line docstrings]
-+    "D400",
-+    # First line should be in imperative mood; try rephrasing
-+    "D401",
-+    ## Disable one in each pair of mutually incompatible rules
-+    # We don’t want a blank line before a class docstring
-+    "D203",
-+    # We want docstrings to start immediately after the opening triple quote
-+    "D213",
-+]
-+
-+[tool.ruff.per-file-ignores]
-+"docs/*" = ["I"]
-+"tests/*" = ["D"]
-+"*/__init__.py" = ["F401"]
- 
- [tool.jupytext]
- formats = "ipynb,md"
+ [tool.ruff.per-file-ignores]
+ "docs/*" = ["I"]
+ "tests/*" = ["D"]


### PR DESCRIPTION
This PR fixes some problems with the CI setup of the scverse-cookiecutter template repo. Last night, [the `codecov` package was pulled from PyPI](https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259). This can easily be replaced, however we've realized our automatic template sync system does not allow us to modify github actions (a security precaution from github), so we need to roll out this update manually.

We're also taking this opportunity to make several other intended changes for to the CI workflow.

We're still looking into how we can avoid this in the future, which will likely require us changing how our template sync system works. This is being tracked in the [scverse/cookiecutter-scverse#138](https://www.github.com/scverse/cookiecutter-scverse/issues/138). 

## Changes

These changes constitute the 0.2.1 release of the template and make the following changes:

* Remove codecov as a dependency since it's been pulled from pypi ([scverse/cookiecutter-scverse#161](https://www.github.com/scverse/cookiecutter-scverse/pull/161))
* Remove usage of deprecated GitHub actions environment variables (these will be removed in a month) ([scverse/cookiecutter-scverse#161](https://www.github.com/scverse/cookiecutter-scverse/pull/161))
* Fix some spurious ruff errors ([scverse/cookiecutter-scverse#156](https://www.github.com/scverse/cookiecutter-scverse/pull/156), [scverse/cookiecutter-scverse#159](https://www.github.com/scverse/cookiecutter-scverse/pull/159))
* Replace the example citation with the scverse manuscript ([scverse/cookiecutter-scverse#160](https://www.github.com/scverse/cookiecutter-scverse/pull/160))
* automatically cancel running CI jobs on new commit ( [scverse/cookiecutter-scverse#158](https://www.github.com/scverse/cookiecutter-scverse/pull/158))

## Additional remarks
* If there are **merge conflicts**, they either show up inline (`>>>>>>>`) or a `.rej` file will have been created for the respective files. You need to address these conflicts manually. Make sure to enable pre-commit.ci (see below) to detect such files.
* The scverse template works best when the [pre-commit.ci](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#pre-commit-ci), [readthedocs](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#documentation-on-readthedocs) and [codecov](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#coverage-tests-with-codecov) services are enabled. Make sure to activate those apps if you haven't already. 
